### PR TITLE
Add property AutoFileSyntax to class TCodeEdit.

### DIFF
--- a/demos/editor.lps
+++ b/demos/editor.lps
@@ -18,7 +18,9 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="frmMain"/>
-        <CursorPos X="32" Y="8"/>
+        <IsVisibleTab Value="True"/>
+        <TopLine Value="73"/>
+        <CursorPos X="32" Y="76"/>
         <UsageCount Value="44"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -26,10 +28,9 @@
       <Unit2>
         <Filename Value="..\source\codeedit.pas"/>
         <IsPartOfProject Value="True"/>
-        <IsVisibleTab Value="True"/>
         <EditorIndex Value="1"/>
-        <TopLine Value="34"/>
-        <CursorPos X="25" Y="45"/>
+        <TopLine Value="4009"/>
+        <CursorPos X="29" Y="4025"/>
         <UsageCount Value="44"/>
         <Loaded Value="True"/>
       </Unit2>
@@ -162,123 +163,122 @@
     <JumpHistory Count="30" HistoryIndex="29">
       <Position1>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1305" TopLine="1293"/>
+        <Caret Line="1321" Column="20" TopLine="1310"/>
       </Position1>
       <Position2>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1176" TopLine="1163"/>
+        <Caret Line="1336" Column="21" TopLine="1322"/>
       </Position2>
       <Position3>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1321" TopLine="1308"/>
+        <Caret Line="1321" TopLine="1319"/>
       </Position3>
       <Position4>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="3516" Column="34" TopLine="3504"/>
+        <Caret Line="1176" TopLine="1157"/>
       </Position4>
       <Position5>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1308" TopLine="1294"/>
+        <Caret Line="1323" TopLine="1314"/>
       </Position5>
       <Position6>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1309" Column="18" TopLine="1294"/>
+        <Caret Line="1330" TopLine="1314"/>
       </Position6>
       <Position7>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1176" TopLine="1163"/>
+        <Caret Line="1323" TopLine="1314"/>
       </Position7>
       <Position8>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1321" Column="20" TopLine="1310"/>
+        <Caret Line="1324" TopLine="1314"/>
       </Position8>
       <Position9>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1336" Column="21" TopLine="1322"/>
+        <Caret Line="1326" TopLine="1314"/>
       </Position9>
       <Position10>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1321" TopLine="1319"/>
+        <Caret Line="1327" TopLine="1314"/>
       </Position10>
       <Position11>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1176" TopLine="1157"/>
+        <Caret Line="1323" Column="8" TopLine="1314"/>
       </Position11>
       <Position12>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1323" TopLine="1314"/>
+        <Caret Line="490" TopLine="478"/>
       </Position12>
       <Position13>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1330" TopLine="1314"/>
+        <Caret Line="1328" Column="3" TopLine="1316"/>
       </Position13>
       <Position14>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1323" TopLine="1314"/>
+        <Caret Line="1523" Column="37" TopLine="1510"/>
       </Position14>
       <Position15>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1324" TopLine="1314"/>
+        <Caret Line="1643" Column="37" TopLine="1630"/>
       </Position15>
       <Position16>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1326" TopLine="1314"/>
+        <Caret Line="2867" TopLine="2853"/>
       </Position16>
       <Position17>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1327" TopLine="1314"/>
+        <Caret Line="2866" Column="13" TopLine="2853"/>
       </Position17>
       <Position18>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1323" Column="8" TopLine="1314"/>
+        <Caret Line="3839" TopLine="3827"/>
       </Position18>
       <Position19>
-        <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="490" TopLine="478"/>
+        <Filename Value="frmmain.pas"/>
+        <Caret Line="44" Column="55" TopLine="44"/>
       </Position19>
       <Position20>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1328" Column="3" TopLine="1316"/>
+        <Caret Line="7"/>
       </Position20>
       <Position21>
-        <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1523" Column="37" TopLine="1510"/>
+        <Filename Value="frmmain.pas"/>
+        <Caret Line="95" Column="32" TopLine="91"/>
       </Position21>
       <Position22>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="1643" Column="37" TopLine="1630"/>
+        <Caret Line="41" TopLine="30"/>
       </Position22>
       <Position23>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="2867" TopLine="2853"/>
+        <Caret Line="748" Column="94" TopLine="744"/>
       </Position23>
       <Position24>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="2866" Column="13" TopLine="2853"/>
+        <Caret Line="341" Column="29" TopLine="337"/>
       </Position24>
       <Position25>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="3839" TopLine="3827"/>
+        <Caret Line="8" Column="46"/>
       </Position25>
       <Position26>
-        <Filename Value="frmmain.pas"/>
-        <Caret Line="44" Column="55" TopLine="44"/>
+        <Filename Value="..\source\codeedit.pas"/>
+        <Caret Line="4751" Column="5" TopLine="4732"/>
       </Position26>
       <Position27>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="7"/>
       </Position27>
       <Position28>
-        <Filename Value="frmmain.pas"/>
-        <Caret Line="95" Column="32" TopLine="91"/>
+        <Filename Value="..\source\codeedit.pas"/>
+        <Caret Line="177" Column="37" TopLine="159"/>
       </Position28>
       <Position29>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="41" TopLine="30"/>
+        <Caret Line="222" Column="80" TopLine="206"/>
       </Position29>
       <Position30>
         <Filename Value="..\source\codeedit.pas"/>
-        <Caret Line="748" Column="94" TopLine="744"/>
+        <Caret Line="1208" Column="18" TopLine="1192"/>
       </Position30>
     </JumpHistory>
   </ProjectSession>

--- a/demos/frmmain.pas
+++ b/demos/frmmain.pas
@@ -73,6 +73,7 @@ implementation
 procedure TMainForm.FormCreate(Sender: TObject);
 begin
   FEdit := PlaceACodeEdit(EditPanel);
+//FEdit.AutoFileSyntax := false;
   FEdit.OnStatus := @EditStatus;
 end;
 

--- a/files.txt
+++ b/files.txt
@@ -1,0 +1,7 @@
+folder:	        demo: Sample TCodeEdit applications
+folder:     resource: Pictures and other resources used for Readme.md and Wikis.
+folder:       source: source codes
+  file:    files.txt: current this file
+  file:      LICENSE: MIT license file
+  file:  LICENSE.txt: MIT license file
+  file:    README.md: TCodeEdit's markdown readme file

--- a/source/codeedit.pas
+++ b/source/codeedit.pas
@@ -138,6 +138,7 @@ type
     FVisibleLines: integer;
     FLine80Pos: integer;
     FWheelTime: TDateTime;
+    FAutoFileSyntax: boolean;
     FOnStatus: TNotifyEvent;
     procedure SetPalette(Value: TPalette);
     procedure SetTabSize(Value: integer);
@@ -218,6 +219,7 @@ type
     property TabSize: integer read FTabSize write SetTabSize;
     property Readonly: boolean read FReadonly write SetReadonly;
     property Modified: boolean read FModified write SetModified;
+    property AutoFileSyntax: boolean read FAutoFileSyntax write FAutoFileSyntax;
     property OnStatus: TNotifyEvent read FOnStatus write FOnStatus;
   end;
 
@@ -1203,6 +1205,7 @@ begin
   Cursor := crIBeam;
   DoubleBuffered := true;
   FTabSize := CE_DEFTABSIZE;
+  FAutoFileSyntax := true;
   FWheelTime := Now;
   Font.Name := CE_FONTNAME;
   Font.Size := CE_FONTSIZE;
@@ -1310,7 +1313,7 @@ begin
   else PaintVisibleLines(has_need_paint, true);
 end;
 
-procedure TCodeEdit.PaintVisibleLines(OnlyNeeded, DoPaint: boolean);
+procedure TCodeEdit.PaintVisibleLines(OnlyNeeded: boolean; DoPaint: boolean);
 var
   I, X, Y: integer;
   L: TLine;
@@ -4019,8 +4022,9 @@ begin
     L.LoadFromFile(FileName);
     LoadFromStrings(L);
     X := ExtractFileExt(FileName);
-    if not FEdit.Syntax.Support(X) then
-      FEdit.Syntax.SyntaxClass := FindSyntaxByFileExt(X);
+    if FEdit.FAutoFileSyntax then
+      if not FEdit.Syntax.Support(X) then
+        FEdit.Syntax.SyntaxClass := FindSyntaxByFileExt(X);
   finally
     L.Free;
   end;


### PR DESCRIPTION
If AutoFileSyntax is set true, TCodeEdit will set file's syntax class automatically base on file extensiton.

procedure TLineList.LoadFromFile(const FileName: string);
var
  L: TStrings;
  X: string;
begin
  L := TStringList.Create;
  try
    L.LoadFromFile(FileName);
    LoadFromStrings(L);
    X := ExtractFileExt(FileName);
    if FEdit.FAutoFileSyntax then
      if not FEdit.Syntax.Support(X) then
        FEdit.Syntax.SyntaxClass := FindSyntaxByFileExt(X);
  finally
    L.Free;
  end;
end;